### PR TITLE
Allow setting of activity title.

### DIFF
--- a/ARChromeActivity/ARChromeActivity.m
+++ b/ARChromeActivity/ARChromeActivity.m
@@ -51,10 +51,6 @@
     return NSStringFromClass([self class]);
 }
 
-- (NSString *)activityTitle {
-    return @"Chrome";
-}
-
 - (BOOL)canPerformWithActivityItems:(NSArray *)activityItems {
 	return [[activityItems lastObject] isKindOfClass:[NSURL class]] && [[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"googlechrome-x-callback://"]];
 }


### PR DESCRIPTION
The `activityTitle` property was `readwrite`, but the getter method always
returned `@"Chrome"`. I deleted the explicit getter, unhiding the
synthesized method.
