### PR TITLE
added iOS 5.0 as deployment target

### DIFF
--- a/ARChromeActivity.podspec
+++ b/ARChromeActivity.podspec
@@ -1,5 +1,6 @@
 Pod::Spec.new do |s|
   s.platform     = :ios, '6.0'
+  s.ios.deployment_target = '5.0'
   s.name         = "ARChromeActivity"
   s.version      = "1.0.0"
   s.summary      = "A UIActivity subclass for opening URLs in Google Chrome."


### PR DESCRIPTION
So the spec is usable in a project the has iOS 5.0 as a deployment target.
