### PR TITLE
iOS 9 visibility fix.

### DIFF
--- a/ARChromeActivity/ARChromeActivity.m
+++ b/ARChromeActivity/ARChromeActivity.m
@@ -57,7 +57,7 @@ static NSString *encodeByAddingPercentEscapes(NSString *input) {
 }
 
 - (BOOL)canPerformWithActivityItems:(NSArray *)activityItems {
-    if (![[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"googlechrome-x-callback://"]]) {
+    if (_callbackURL && ![[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"googlechrome-x-callback://"]]) {
         return NO;
     }
     for (id item in activityItems){


### PR DESCRIPTION
Hello!
`canOpenURL:` works differently under iOS 9. And prevents this activity from appearing even if no x-callback is set. 
A workaround (for now) is to not check availability of x-callback URLS if  `callbackURL` is not set. 
This allows the activity to be usable (just without x-callback).

Under iOS9 there might be a better option with universal links but I think that is on chrome for iOS's side of things to expose.