### PR TITLE
Pod framework support

### DIFF
--- a/ARChromeActivity/ARChromeActivity.m
+++ b/ARChromeActivity/ARChromeActivity.m
@@ -49,7 +49,11 @@ static NSString *encodeByAddingPercentEscapes(NSString *input) {
 }
 
 - (UIImage *)activityImage {
-    return [UIImage imageNamed:@"ARChromeActivity"];
+    if ([[UIImage class] respondsToSelector:@selector(imageNamed:inBundle:compatibleWithTraitCollection:)]) {
+        return [UIImage imageNamed:@"ARChromeActivity" inBundle:[NSBundle bundleForClass:self.class] compatibleWithTraitCollection:nil];
+    } else {
+        return [UIImage imageNamed:@"ARChromeActivity"];
+    }
 }
 
 - (NSString *)activityType {


### PR DESCRIPTION
Add support for projects where ARChromeActivity is not in the main bundle (such as CocoaPods frameworks). The fallback is included for iOS 7 and earlier.

Addresses https://github.com/alextrob/ARChromeActivity/issues/21 and https://github.com/alextrob/ARChromeActivity/issues/14.
